### PR TITLE
Improve handling of special links

### DIFF
--- a/pkg/crawler/fetcher.go
+++ b/pkg/crawler/fetcher.go
@@ -56,7 +56,9 @@ func parsePage(pageBody io.ReadCloser) (title string, links []string) {
 				for _, a := range t.Attr {
 					if a.Key == "href" {
 						if isLinkToArticle(a.Val) {
-							links = append(links, a.Val)
+							// Handle links to section: /path/to/doc#section
+							link := s.SplitN(a.Val, "#", 2)[0]
+							links = append(links, link)
 						}
 						break
 					}

--- a/pkg/crawler/fetcher.go
+++ b/pkg/crawler/fetcher.go
@@ -2,6 +2,7 @@ package crawler
 
 import (
 	"io"
+	"log"
 	"net/http"
 	s "strings"
 
@@ -63,7 +64,7 @@ func parsePage(client *http.Client, pageBody io.ReadCloser) (title string, links
 							// to ensure we have the actual article URL
 							res, err := client.Head(link)
 							if err != nil {
-								panic(err)
+								log.Printf("failed to fetch %s: %s", link, err)
 							}
 							links = append(links, res.Request.URL.String())
 						}

--- a/pkg/crawler/fetcher.go
+++ b/pkg/crawler/fetcher.go
@@ -58,7 +58,14 @@ func parsePage(pageBody io.ReadCloser) (title string, links []string) {
 						if isLinkToArticle(a.Val) {
 							// Handle links to section: /path/to/doc#section
 							link := s.SplitN(a.Val, "#", 2)[0]
-							links = append(links, link)
+
+							// Do a head request and follow redirects
+							// to ensure we have the actual article URL
+							res, err := http.Head(link)
+							if err != nil {
+								panic(err)
+							}
+							links = append(links, res.Request.URL.String())
 						}
 						break
 					}

--- a/pkg/crawler/fetcher.go
+++ b/pkg/crawler/fetcher.go
@@ -17,7 +17,7 @@ func CrawlArticle(url string) db.Article {
 	}
 	defer resp.Body.Close()
 
-	title, links := parsePage(resp.Body)
+	title, links := parsePage(http.DefaultClient, resp.Body)
 
 	dedupedLinks := removeDuplicates(links)
 
@@ -36,7 +36,7 @@ func CrawlArticle(url string) db.Article {
 	}
 }
 
-func parsePage(pageBody io.ReadCloser) (title string, links []string) {
+func parsePage(client *http.Client, pageBody io.ReadCloser) (title string, links []string) {
 	z := html.NewTokenizer(pageBody)
 
 	titleIsNext := false
@@ -61,7 +61,7 @@ func parsePage(pageBody io.ReadCloser) (title string, links []string) {
 
 							// Do a head request and follow redirects
 							// to ensure we have the actual article URL
-							res, err := http.Head(link)
+							res, err := client.Head(link)
 							if err != nil {
 								panic(err)
 							}


### PR DESCRIPTION
* links to sections: `/path#section`
* links to moved pages (302 redirects)